### PR TITLE
add function for defining outputs, resources in config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,7 +2,7 @@
 bids_dir: 'bids'  
 
 opts:
-  hippunfold: '--modality T1w --output-density 0p5mm 1mm 2mm'
+  hippunfold: '--modality T1w --output-density 0p5mm 1mm 2mm --keep-work'
 
   
 resources:

--- a/config.yml
+++ b/config.yml
@@ -2,8 +2,14 @@
 bids_dir: 'bids'  
 
 opts:
-  hippunfold: '--modality T1w --skip-coreg --skip-preproc --output-density 0p5mm 1mm 2mm --generate-myelin-map'
+  hippunfold: '--modality T1w --output-density 0p5mm 1mm 2mm'
 
+  
+#may need to bump this up if you have multiple sessions per subject, try cores=32, mem_mb=128000, time=180 
+resources:
+  cores: 8
+  mem_mb: 32000
+  time: 90 
 
 #-- uncomment this section to run on a subset of subjects --
 #test_subjects:   

--- a/config.yml
+++ b/config.yml
@@ -5,11 +5,10 @@ opts:
   hippunfold: '--modality T1w --output-density 0p5mm 1mm 2mm'
 
   
-#may need to bump this up if you have multiple sessions per subject, try cores=32, mem_mb=128000, time=180 
 resources:
-  cores: 8
-  mem_mb: 32000
-  time: 90 
+  cores: 32
+  mem_mb: 128000
+  time: 180 
 
 #-- uncomment this section to run on a subset of subjects --
 #test_subjects:   


### PR DESCRIPTION
- should work with or without --keep-work now..
- can change job resources from the config file now

To do:
- [x] test that copying from tmp works as expected